### PR TITLE
Add service bus trigger to receive messages from gateway

### DIFF
--- a/src/Modkit/Gateway/Program.fs
+++ b/src/Modkit/Gateway/Program.fs
@@ -30,3 +30,7 @@ let client = host.Services.GetRequiredService<Client>()
 client.StartAsync()
 |> Async.AwaitTask
 |> Async.RunSynchronously
+
+client.ReceiveMessagesAsync()
+|> Async.AwaitTask
+|> Async.RunSynchronously


### PR DESCRIPTION
Fixes #2

Add a service bus trigger to receive messages from the gateway.

* **Client.fs**
  - Add `ReceiveMessagesAsync` method to receive and process messages from the service bus queue.
  - Update `StartAsync` method to call `ReceiveMessagesAsync`.

* **Program.fs**
  - Call `ReceiveMessagesAsync` method of the `Client` class to start receiving messages.

